### PR TITLE
fix(Login, Register): update navigation links for account registration and login

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -15,7 +15,10 @@ export default function Login() {
     e.preventDefault();
     setLoading(true);
     setError("");
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
     if (error) setError(error.message);
     else navigate("/");
     setLoading(false);
@@ -29,14 +32,14 @@ export default function Login() {
           type="email"
           placeholder="Email"
           value={email}
-          onChange={e => setEmail(e.target.value)}
+          onChange={(e) => setEmail(e.target.value)}
           required
         />
         <Input
           type="password"
           placeholder="Password"
           value={password}
-          onChange={e => setPassword(e.target.value)}
+          onChange={(e) => setPassword(e.target.value)}
           required
         />
         {error && <div className="text-red-500 text-sm">{error}</div>}
@@ -44,7 +47,10 @@ export default function Login() {
           {loading ? "Logging in..." : "Login"}
         </Button>
         <div className="text-sm text-center">
-          Don't have an account? <a href="/register" className="text-blue-500 underline">Register</a>
+          Don't have an account?
+          <Link to="/register" className="text-blue-500 underline">
+            Register
+          </Link>
         </div>
       </form>
     </div>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -34,14 +34,14 @@ export default function Register() {
           type="email"
           placeholder="Email"
           value={email}
-          onChange={e => setEmail(e.target.value)}
+          onChange={(e) => setEmail(e.target.value)}
           required
         />
         <Input
           type="password"
           placeholder="Password"
           value={password}
-          onChange={e => setPassword(e.target.value)}
+          onChange={(e) => setPassword(e.target.value)}
           required
         />
         {error && <div className="text-red-500 text-sm">{error}</div>}
@@ -50,7 +50,13 @@ export default function Register() {
           {loading ? "Registering..." : "Register"}
         </Button>
         <div className="text-sm text-center">
-          Already have an account? <a href="/login" className="text-blue-500 underline">Login</a>
+          <Link to="/login" className="text-blue-500 underline">
+            Login
+          </Link>
+          Already have an account?
+          <Link to="/login" className="text-blue-500 underline">
+            Login
+          </Link>
         </div>
       </form>
     </div>


### PR DESCRIPTION

# Pull Request

## Title
Update links for account registration and login

## Description
Current implementation of Login and Registration page routing did not implemented the `react-router-dom` causing it to throw 404 error on Live.

Fixes #(issue)
Removed anchor based page links from login and registration routes and updated to use Link from `react-router-dom`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?
Navigated to login page and then clicked on `Register`. A full page refresh did not happened and instead was routed to 
/register.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes (optional)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the PR here. -->
